### PR TITLE
@joeyAghion => Bump scala-common-enrich to 0.2.2-SNAPSHOT

### DIFF
--- a/3-enrich/scala-kinesis-enrich/project/Dependencies.scala
+++ b/3-enrich/scala-kinesis-enrich/project/Dependencies.scala
@@ -40,7 +40,7 @@ object Dependencies {
     val config               = "1.0.2"
     val scalaUtil            = "0.1.0"
     val snowplowRawEvent     = "0.1.0"
-    val snowplowCommonEnrich = "0.2.1-SNAPSHOT"
+    val snowplowCommonEnrich = "0.2.2-SNAPSHOT"
     val scalazon             = "0.5"
     val scalaz7              = "7.0.0"
     val maxmindGeoip         = "0.0.5"
@@ -71,7 +71,7 @@ object Dependencies {
     val config               = "com.typesafe"               %  "config"                   % V.config
     val scalaUtil            = "com.snowplowanalytics"      %  "scala-util"               % V.scalaUtil
     val snowplowRawEvent     = "com.snowplowanalytics"      % "snowplow-thrift-raw-event" % V.snowplowRawEvent
-    val snowplowCommonEnrich = "com.github.ilyakava"        %% "snowplow-common-enrich"   % V.snowplowCommonEnrich
+    val snowplowCommonEnrich = "com.github.artsy"           %% "snowplow-common-enrich"   % V.snowplowCommonEnrich
     val scalazon             = "io.github.cloudify"         %% "scalazon"                 % V.scalazon
     val scalaz7              = "org.scalaz"                 %% "scalaz-core"              % V.scalaz7
     // Scala (test only)


### PR DESCRIPTION
This PR shifts the common-enrich library, which was moved over to artsy sonatype in: https://github.com/artsy/snowplow/pull/2 to be pulled from that repository, as well as getting the latest version.

@joeyAghion want to deploy this app (scala-kinesis-enrich) as followup?
