### PR TITLE
@ilyakava => truncating version names to keep numbers but be short enough for redshift

### DIFF
--- a/3-enrich/scala-common-enrich/src/main/scala/com.snowplowanalytics.snowplow.enrich/common/enrichments/MiscEnrichments.scala
+++ b/3-enrich/scala-common-enrich/src/main/scala/com.snowplowanalytics.snowplow.enrich/common/enrichments/MiscEnrichments.scala
@@ -28,7 +28,7 @@ import generated.ProjectSettings
  * one of the other modules.
  */
 object MiscEnrichments {
-  
+
   /**
    * The version of this ETL. Appends this version
    * to the supplied "host" ETL.
@@ -38,7 +38,10 @@ object MiscEnrichments {
    * @return the complete ETL version
    */
   def etlVersion(hostEtlVersion: String): String =
-    "%s-common-%s".format(hostEtlVersion, ProjectSettings.version.replace("SNAPSHOT", "S"))
+    if (ProjectSettings.version.contains("SNAPSHOT"))
+      "e-%s-l-%s-s".format(hostEtlVersion.replaceAll("[^\\d.]", ""), ProjectSettings.version.replace("SNAPSHOT", "").replaceAll("[^\\d.]", ""))
+    else
+      "e-%s-l-%s".format(hostEtlVersion.replaceAll("[^\\d.]", ""), ProjectSettings.version.replace("SNAPSHOT", "").replaceAll("[^\\d.]", ""))
 
   /**
    * Validate the specified

--- a/3-enrich/scala-common-enrich/src/test/scala/com.snowplowanalytics.snowplow.enrich.common/enrichments/miscEnrichmentTests.scala
+++ b/3-enrich/scala-common-enrich/src/test/scala/com.snowplowanalytics.snowplow.enrich.common/enrichments/miscEnrichmentTests.scala
@@ -31,7 +31,7 @@ class EtlVersionTest extends MutSpecification {
 
   "The ETL version" should {
     "be successfully returned" in {
-      MiscEnrichments.etlVersion("hadoop-0.3.6") must_== "hadoop-0.3.6-common-0.2.0-SNAPSHOT"
+      MiscEnrichments.etlVersion("hadoop-0.3.6") must_== "e-0.3.6-l-0.2.2-s"
     }
   }
 }


### PR DESCRIPTION
Now truncates versions to `e - <version #> - c - <version #> - s (if it is a SNAPSHOT)`

This is so the string will fit within redshift's <28 char field limit.
