### PR TITLE
@wrgoldstein => Scala common enrich impressions

### DIFF
--- a/3-enrich/scala-common-enrich/project/BuildSettings.scala
+++ b/3-enrich/scala-common-enrich/project/BuildSettings.scala
@@ -21,7 +21,7 @@ object BuildSettings {
   // Basic settings for our app
   lazy val basicSettings = Seq[Setting[_]](
     organization          :=  "com.github.artsy", // had to change it from com.snowplowanalytics for sonatype
-    version               :=  "0.2.3-SNAPSHOT",
+    version               :=  "0.2.4-SNAPSHOT",
     description           :=  "Common functionality for enriching raw Snowplow events",
     scalaVersion          :=  "2.10.1",
     scalacOptions         :=  Seq("-deprecation", "-encoding", "utf8",

--- a/3-enrich/scala-common-enrich/project/Dependencies.scala
+++ b/3-enrich/scala-common-enrich/project/Dependencies.scala
@@ -13,7 +13,7 @@
 import sbt._
 
 object Dependencies {
-  
+
   val resolutionRepos = Seq(
     // Required for our Scalaz snapshot
     "Sonatype Snapshots" at "https://oss.sonatype.org/content/repositories/releases/",
@@ -36,9 +36,12 @@ object Dependencies {
     val yodaTime         = "2.1"
     val yodaConvert      = "1.2"
     val useragent        = "1.11"
+    val commonsBeanUtils = "1.9.2"
     // Scala
     val scalaz7          = "7.0.0"
     val argonaut         = "6.0"
+    // for anyone wondering where snowplowRawEvent comes from:
+    // 2-collectors/thrift-raw-event/src/main/thrift/snowplow-raw-event.thrift
     val snowplowRawEvent = "0.1.0-SNAPSHOT"
     val scalaUtil        = "0.1.0"
     val refererParser    = "0.1.1"
@@ -58,6 +61,7 @@ object Dependencies {
     // Java
     val httpClient       = "org.apache.httpcomponents"  %  "httpclient"               % V.http
     val commonsLang      = "org.apache.commons"         %  "commons-lang3"            % V.commonsLang
+    val commonsBeanUtils = "commons-beanutils"          %  "commons-beanutils"        % V.commonsBeanUtils
     val commonsIo        = "commons-io"                 %  "commons-io"               % V.commonsIo
     val yodaTime         = "joda-time"                  %  "joda-time"                % V.yodaTime
     val yodaConvert      = "org.joda"                   %  "joda-convert"             % V.yodaConvert

--- a/3-enrich/scala-common-enrich/project/SnowplowCommonEnrichBuild.scala
+++ b/3-enrich/scala-common-enrich/project/SnowplowCommonEnrichBuild.scala
@@ -1,4 +1,4 @@
-/* 
+/*
  * Copyright (c) 2012-2014 Snowplow Analytics Ltd. All rights reserved.
  *
  * This program is licensed to you under the Apache License Version 2.0, and
@@ -36,6 +36,7 @@ object SnowplowCommonEnrichBuild extends Build {
         Libraries.yodaTime,
         Libraries.yodaConvert,
         Libraries.commonsLang,
+        Libraries.commonsBeanUtils,
         Libraries.commonsIo,
         Libraries.useragent,
         // Scala

--- a/3-enrich/scala-common-enrich/src/main/scala/com.snowplowanalytics.snowplow.enrich/common/enrichments/MiscEnrichments.scala
+++ b/3-enrich/scala-common-enrich/src/main/scala/com.snowplowanalytics.snowplow.enrich/common/enrichments/MiscEnrichments.scala
@@ -38,6 +38,7 @@ object MiscEnrichments {
    * @return the complete ETL version
    */
   def etlVersion(hostEtlVersion: String): String =
+    // the e in this short string stands for enricher (the host), l stands for library (this project)
     if (ProjectSettings.version.contains("SNAPSHOT"))
       "e-%s-l-%s-s".format(hostEtlVersion.replaceAll("[^\\d.]", ""), ProjectSettings.version.replace("SNAPSHOT", "").replaceAll("[^\\d.]", ""))
     else

--- a/3-enrich/scala-common-enrich/src/test/scala/com.snowplowanalytics.snowplow.enrich.common/enrichments/miscEnrichmentTests.scala
+++ b/3-enrich/scala-common-enrich/src/test/scala/com.snowplowanalytics.snowplow.enrich.common/enrichments/miscEnrichmentTests.scala
@@ -31,7 +31,9 @@ class EtlVersionTest extends MutSpecification {
 
   "The ETL version" should {
     "be successfully returned" in {
-      MiscEnrichments.etlVersion("hadoop-0.3.6") must_== "e-0.3.6-l-0.2.2-s"
+      val truncates = MiscEnrichments.etlVersion("veryLongHostsNameToTruncate-0.3.6").contains("e-0.3.6-l-")
+      val isShort = MiscEnrichments.etlVersion("veryLongHostsNameToTruncate-0.3.6").length < 25
+      (truncates && isShort) must_== true
     }
   }
 }


### PR DESCRIPTION
As you can tell, nothing exciting here. Unfort, a special case for impressions to split up a field that will be comma separated, this is the format that we expect if we send an array from the JS tracker. The spec for this is integrated to my other PR that uses this library in scala-kinesis-enrich: https://github.com/artsy/snowplow/pull/6