### PR TITLE
@wrgoldstein => Scala kinesis enrich impressions

### DIFF
--- a/3-enrich/scala-kinesis-enrich/myconf.conf
+++ b/3-enrich/scala-kinesis-enrich/myconf.conf
@@ -24,8 +24,10 @@ enrich {
       raw: ${KINESIS_IN_STREAM}
     }
     out: {
-      enriched: ${KINESIS_OUT_STREAM}
-      enriched_shards: 1 # Number of shards to use if created.
+      canonical: ${KINESIS_OUT_CANONICAL_STREAM}
+      canonical_shards: ${KINESIS_OUT_CANONICAL_SHARDS} # Number of shards to use if created.
+      impressions: ${KINESIS_OUT_IMPRESSIONS_STREAM}
+      impressions_shards: ${KINESIS_OUT_IMPRESSIONS_SHARDS}
       bad: "SnowplowBad" # Not used until #463
       bad_shards: 1 # Number of shards to use if created.
     }

--- a/3-enrich/scala-kinesis-enrich/myconf.conf
+++ b/3-enrich/scala-kinesis-enrich/myconf.conf
@@ -26,8 +26,8 @@ enrich {
     out: {
       canonical: ${KINESIS_OUT_CANONICAL_STREAM}
       canonical_shards: ${KINESIS_OUT_CANONICAL_SHARDS} # Number of shards to use if created.
-      impressions: ${KINESIS_OUT_IMPRESSIONS_STREAM}
-      impressions_shards: ${KINESIS_OUT_IMPRESSIONS_SHARDS}
+      impression: ${KINESIS_OUT_IMPRESSION_STREAM}
+      impression_shards: ${KINESIS_OUT_IMPRESSION_SHARDS}
       bad: "SnowplowBad" # Not used until #463
       bad_shards: 1 # Number of shards to use if created.
     }

--- a/3-enrich/scala-kinesis-enrich/project/Dependencies.scala
+++ b/3-enrich/scala-kinesis-enrich/project/Dependencies.scala
@@ -40,7 +40,7 @@ object Dependencies {
     val config               = "1.0.2"
     val scalaUtil            = "0.1.0"
     val snowplowRawEvent     = "0.1.0"
-    val snowplowCommonEnrich = "0.2.3-SNAPSHOT"
+    val snowplowCommonEnrich = "0.2.4-SNAPSHOT"
     val scalazon             = "0.5"
     val scalaz7              = "7.0.0"
     val maxmindGeoip         = "0.0.5"

--- a/3-enrich/scala-kinesis-enrich/src/main/scala/com.snowplowanalytics.snowplow.enrich.kinesis/KinesisEnrichApp.scala
+++ b/3-enrich/scala-kinesis-enrich/src/main/scala/com.snowplowanalytics.snowplow.enrich.kinesis/KinesisEnrichApp.scala
@@ -111,10 +111,10 @@ class KinesisEnrichConfig(config: Config) {
   val rawInStream = inStreams.getString("raw")
 
   private val outStreams = streams.getConfig("out")
-  val enrichedOutStream = outStreams.getString("enriched")
-  val enrichedOutStreamShards = outStreams.getInt("enriched_shards")
-  val badOutStream = outStreams.getString("bad")
-  val badOutStreamShards = outStreams.getInt("bad_shards")
+
+  def outStreamInfoFor(genericStreamName: String) = {
+    (outStreams.getString(genericStreamName), outStreams.getInt(genericStreamName + "_shards"))
+  }
 
   val appName = streams.getString("app-name")
 

--- a/3-enrich/scala-kinesis-enrich/src/main/scala/com.snowplowanalytics.snowplow.enrich.kinesis/sinks/ISink.scala
+++ b/3-enrich/scala-kinesis-enrich/src/main/scala/com.snowplowanalytics.snowplow.enrich.kinesis/sinks/ISink.scala
@@ -31,6 +31,9 @@ trait ISink {
    * CanonicalOutput takes the form of a tab-delimited
    * String until such time as https://github.com/snowplow/snowplow/issues/211
    * is implemented.
+   *
+   * TODO: this needs to indicate the [canonical|impression]-ness of the
+   * storage desired via a type, not a string acting as a symbol of this concept
    */
-  def storeCanonicalOutput(output: String, key: String)
+  def storeOutput(output: String, key: String, genericStreamName: String = "canonical")
 }

--- a/3-enrich/scala-kinesis-enrich/src/main/scala/com.snowplowanalytics.snowplow.enrich.kinesis/sinks/StdouterrSink.scala
+++ b/3-enrich/scala-kinesis-enrich/src/main/scala/com.snowplowanalytics.snowplow.enrich.kinesis/sinks/StdouterrSink.scala
@@ -35,7 +35,7 @@ class StdouterrSink extends ISink {
    * String until such time as https://github.com/snowplow/snowplow/issues/211
    * is implemented.
    */
-  def storeCanonicalOutput(output: String, key: String) {
+  def storeOutput(output: String, key: String, genericStreamName: String = "canonical") {
     println(output) // To stdout
   }
 }

--- a/3-enrich/scala-kinesis-enrich/src/main/scala/com.snowplowanalytics.snowplow.enrich.kinesis/sources/KinesisSource.scala
+++ b/3-enrich/scala-kinesis-enrich/src/main/scala/com.snowplowanalytics.snowplow.enrich.kinesis/sources/KinesisSource.scala
@@ -60,8 +60,8 @@ import collectors.thrift.{
  * TODO: replace printlns with using Java logger
  */
 class KinesisSource(config: KinesisEnrichConfig)
-    extends AbstractSource(config) {
-  
+  extends AbstractSource(config) {
+
   /**
    * Never-ending processing loop over source stream.
    */
@@ -72,17 +72,17 @@ class KinesisSource(config: KinesisEnrichConfig)
 
     val kinesisClientLibConfiguration = new KinesisClientLibConfiguration(
       config.appName,
-      config.rawInStream, 
+      config.rawInStream,
       kinesisProvider,
       workerId
     ).withInitialPositionInStream(
       InitialPositionInStream.valueOf(config.initialPosition)
     )
-    
+
     println(s"Running: ${config.appName}.")
     println(s"Processing raw input stream: ${config.rawInStream}")
 
-    
+
     val rawEventProcessorFactory = new RawEventProcessorFactory(
       config,
       sink.get // TODO: yech
@@ -118,7 +118,7 @@ class KinesisSource(config: KinesisEnrichConfig)
     private val BACKOFF_TIME_IN_MILLIS = 3000L
     private val NUM_RETRIES = 10
     private val CHECKPOINT_INTERVAL_MILLIS = 1000L
-      
+
     @Override
     def initialize(shardId: String) = {
       println("Initializing record processor for shard: " + shardId)
@@ -161,7 +161,7 @@ class KinesisSource(config: KinesisEnrichConfig)
         checkpoint(checkpointer)
       }
     }
-      
+
     private def checkpoint(checkpointer: IRecordProcessorCheckpointer) = {
       println(s"Checkpointing shard $kinesisShardId")
       breakable {

--- a/3-enrich/scala-kinesis-enrich/src/main/scala/com.snowplowanalytics.snowplow.enrich.kinesis/sources/TestSource.scala
+++ b/3-enrich/scala-kinesis-enrich/src/main/scala/com.snowplowanalytics.snowplow.enrich.kinesis/sources/TestSource.scala
@@ -25,7 +25,7 @@ package sources
  * sources.
  */
 class TestSource(config: KinesisEnrichConfig)
-    extends AbstractSource(config) {
+  extends AbstractSource(config){
 
   /**
    * Never-ending processing loop over source stream.

--- a/3-enrich/scala-kinesis-enrich/src/test/scala/com.snowplowanalytics.snowplow.enrich.kinesis/SpecHelpers.scala
+++ b/3-enrich/scala-kinesis-enrich/src/test/scala/com.snowplowanalytics.snowplow.enrich.kinesis/SpecHelpers.scala
@@ -163,8 +163,8 @@ enrich {
     out: {
       canonical: "SnowplowEnriched"
       canonical_shards: 1 # Number of shards to use if created.
-      impressions: "SnowplowEnrichedImpressions"
-      impressions_shards: 1 # Number of shards to use if created.
+      impression: "SnowplowEnrichedImpression"
+      impression_shards: 1 # Number of shards to use if created.
       bad: "SnowplowBad" # Not used until #463
       bad_shards: 1 # Number of shards to use if created.
     }

--- a/3-enrich/scala-kinesis-enrich/src/test/scala/com.snowplowanalytics.snowplow.enrich.kinesis/SpecHelpers.scala
+++ b/3-enrich/scala-kinesis-enrich/src/test/scala/com.snowplowanalytics.snowplow.enrich.kinesis/SpecHelpers.scala
@@ -161,8 +161,10 @@ enrich {
       raw: "SnowplowRaw"
     }
     out: {
-      enriched: "SnowplowEnriched"
-      enriched_shards: 1 # Number of shards to use if created.
+      canonical: "SnowplowEnriched"
+      canonical_shards: 1 # Number of shards to use if created.
+      impressions: "SnowplowEnrichedImpressions"
+      impressions_shards: 1 # Number of shards to use if created.
       bad: "SnowplowBad" # Not used until #463
       bad_shards: 1 # Number of shards to use if created.
     }

--- a/3-enrich/scala-kinesis-enrich/src/test/scala/com.snowplowanalytics.snowplow.enrich.kinesis/SpecHelpers.scala
+++ b/3-enrich/scala-kinesis-enrich/src/test/scala/com.snowplowanalytics.snowplow.enrich.kinesis/SpecHelpers.scala
@@ -1,4 +1,4 @@
-/* 
+/*
  * Copyright (c) 2013-2014 Snowplow Analytics Ltd. All rights reserved.
  *
  * This program is licensed to you under the Apache License Version 2.0, and
@@ -36,9 +36,10 @@ import common.outputs.CanonicalOutput
 object SpecHelpers {
 
   /**
-   * The Kinesis Enrich being used
+   * The Kinesis Enrich being used. Really doesn't matter
+   * and changes with version numbers
    */
-  val EnrichVersion = "kinesis-0.1.0-common-0.2.0"
+  val EnrichVersion = ".{1,25}"
 
   /**
    * The regexp pattern for a Type 4 UUID.
@@ -54,7 +55,7 @@ object SpecHelpers {
    * Fields in our CanonicalOutput which will be checked
    * against a regexp, not for equality.
    */
-  private val UseRegexpFields = List("event_id")
+  private val UseRegexpFields = List("event_id", "v_etl")
 
   /**
    * Fields in our CanonicalOutput which are discarded

--- a/3-enrich/scala-kinesis-enrich/src/test/scala/com.snowplowanalytics.snowplow.enrich.kinesis/bad/CorruptedThriftLinesSpec.scala
+++ b/3-enrich/scala-kinesis-enrich/src/test/scala/com.snowplowanalytics.snowplow.enrich.kinesis/bad/CorruptedThriftLinesSpec.scala
@@ -1,4 +1,4 @@
-/* 
+/*
  * Copyright (c) 2013-2014 Snowplow Analytics Ltd. All rights reserved.
  *
  * This program is licensed to you under the Apache License Version 2.0, and
@@ -41,7 +41,7 @@ class CorruptedThriftLinesSpec extends Specification with ScalaCheck { def is =
   def e1 = check {
     (raw: String) => {
       val eventBytes = Base64.decodeBase64(raw)
-      TestSource.enrichEvent(eventBytes) must beNone
+      TestSource.enrichEvent(eventBytes) must_== Array(None)
     }
   }
 

--- a/3-enrich/scala-kinesis-enrich/src/test/scala/com.snowplowanalytics.snowplow.enrich.kinesis/bad/InvalidEnrichedEventSpec.scala
+++ b/3-enrich/scala-kinesis-enrich/src/test/scala/com.snowplowanalytics.snowplow.enrich.kinesis/bad/InvalidEnrichedEventSpec.scala
@@ -1,4 +1,4 @@
-/* 
+/*
  * Copyright (c) 2013-2014 Snowplow Analytics Ltd. All rights reserved.
  *
  * This program is licensed to you under the Apache License Version 2.0, and
@@ -38,9 +38,9 @@ class InvalidEnrichedEventSpec extends Specification {
     "return None for a valid SnowplowRawEvent which fails enrichment" in {
 
       val rawEvent = Base64.decodeBase64(InvalidEnrichedEventSpec.raw)
-      
-      val enrichedEvent = TestSource.enrichEvent(rawEvent)
-      enrichedEvent must beNone
+
+      val enrichedEvents = TestSource.enrichEvent(rawEvent)
+      enrichedEvents must_== Array(None)
     }
   }
 }

--- a/3-enrich/scala-kinesis-enrich/src/test/scala/com.snowplowanalytics.snowplow.enrich.kinesis/good/ImpressionEventSpec.scala
+++ b/3-enrich/scala-kinesis-enrich/src/test/scala/com.snowplowanalytics.snowplow.enrich.kinesis/good/ImpressionEventSpec.scala
@@ -1,0 +1,264 @@
+/*
+ * Copyright (c) 2013-2014 Snowplow Analytics Ltd. All rights reserved.
+ *
+ * This program is licensed to you under the Apache License Version 2.0, and
+ * you may not use this file except in compliance with the Apache License
+ * Version 2.0.  You may obtain a copy of the Apache License Version 2.0 at
+ * http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the Apache License Version 2.0 is distributed on an "AS
+ * IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the Apache License Version 2.0 for the specific language
+ * governing permissions and limitations there under.
+ */
+package com.snowplowanalytics.snowplow
+package enrich.kinesis
+package good
+
+// Commons Codec
+import org.apache.commons.codec.binary.Base64
+
+// Specs2
+import org.specs2.mutable.Specification
+import org.specs2.execute.Result
+
+// This project
+import SpecHelpers._
+
+object ImpressionEventSpec {
+
+  val raw = "CgABAAABQ/Sevy0LABQAAAAQc3NjLTAuMS4wLXN0ZG91dAsAHgAAAAVVVEYtOAsAKAAAAAgxMC4wLjIuMgwAKQgAAQAAAAEIAAIAAAABCwADAAABvGU9c2Umc2VfY2E9aW1wcmVzc2lvbiZzZV9hYz1iJnNlX2xhPXJ0d29yazEsYXJ0d29yazAyJnNlX3ZhPTAuMCZkdG09MTM5MTM3ODQ4MTA3MSZ0aWQ9MzQ0MjE0JnZwPTE2ODB4NDE1JmRzPTE2ODB4NDE1JnZpZD0yNiZkdWlkPTNjMTc1NzU0NGUzOWJjYTQmcD13ZWImdHY9anMtMC4xMy4xJmZwPTE4MDQ5NTQ3OTAmYWlkPUNGZTIzYSZsYW5nPWVuLVVTJmNzPVVURi04JnR6PUV1cm9wZS9Mb25kb24mdWlkPWFsZXgrMTIzJmZfcGRmPTAmZl9xdD0xJmZfcmVhbHA9MCZmX3dtYT0wJmZfZGlyPTAmZl9mbGE9MSZmX2phdmE9MCZmX2dlYXJzPTAmZl9hZz0wJnJlcz0xOTIweDEwODAmY2Q9MjQmY29va2llPTEmdXJsPWZpbGU6Ly9maWxlOi8vL1VzZXJzL2FsZXgvRGV2ZWxvcG1lbnQvZGV2LWVudmlyb25tZW50L2RlbW8vMS10cmFja2VyL2V2ZW50cy5odG1sL292ZXJyaWRkZW4tdXJsLwALAC0AAAAJbG9jYWxob3N0CwAyAAAAUU1vemlsbGEvNS4wIChNYWNpbnRvc2g7IEludGVsIE1hYyBPUyBYIDEwLjk7IHJ2OjI2LjApIEdlY2tvLzIwMTAwMTAxIEZpcmVmb3gvMjYuMA8ARgsAAAAHAAAAFkNvbm5lY3Rpb246IGtlZXAtYWxpdmUAAAJwQ29va2llOiBfX3V0bWE9MTExODcyMjgxLjg3ODA4NDQ4Ny4xMzkwMjM3MTA3LjEzOTA5MzE1MjEuMTM5MTExMDU4Mi43OyBfX3V0bXo9MTExODcyMjgxLjEzOTAyMzcxMDcuMS4xLnV0bWNzcj0oZGlyZWN0KXx1dG1jY249KGRpcmVjdCl8dXRtY21kPShub25lKTsgX3NwX2lkLjFmZmY9Yjg5YTZmYTYzMWVlZmFjMi4xMzkwMjM3MTA3LjcuMTM5MTExMTgxOS4xMzkwOTMxNTQ1OyBoYmxpZD1DUGpqdWh2RjA1emt0UDdKN001Vm8zTklHUExKeTFTRjsgb2xmc2s9b2xmc2s1NjI5MjM2MzU2MTc1NTQ7IHNwPTc1YTEzNTgzLTVjOTktNDBlMy04MWZjLTU0MTA4NGRmYzc4NDsgd2NzaWQ9S1JoaGs0SEVMcDJBaXBxTDdNNVZvbkNQT1B5QW5GMUo7IF9va2x2PTEzOTExMTE3NzkzMjglMkNLUmhoazRIRUxwMkFpcHFMN001Vm9uQ1BPUHlBbkYxSjsgX191dG1jPTExMTg3MjI4MTsgX29rYms9Y2Q0JTNEdHJ1ZSUyQ3ZpNSUzRDAlMkN2aTQlM0QxMzkxMTEwNTg1NDkwJTJDdmkzJTNEYWN0aXZlJTJDdmkyJTNEZmFsc2UlMkN2aTElM0RmYWxzZSUyQ2NkOCUzRGNoYXQlMkNjZDYlM0QwJTJDY2Q1JTNEYXdheSUyQ2NkMyUzRGZhbHNlJTJDY2QyJTNEMCUyQ2NkMSUzRDAlMkM7IF9vaz05NzUyLTUwMy0xMC01MjI3AAAAHkFjY2VwdC1FbmNvZGluZzogZ3ppcCwgZGVmbGF0ZQAAABpBY2NlcHQtTGFuZ3VhZ2U6IGVuLVVTLCBlbgAAACtBY2NlcHQ6IGltYWdlL3BuZywgaW1hZ2UvKjtxPTAuOCwgKi8qO3E9MC41AAAAXVVzZXItQWdlbnQ6IE1vemlsbGEvNS4wIChNYWNpbnRvc2g7IEludGVsIE1hYyBPUyBYIDEwLjk7IHJ2OjI2LjApIEdlY2tvLzIwMTAwMTAxIEZpcmVmb3gvMjYuMAAAABRIb3N0OiBsb2NhbGhvc3Q6NDAwMQsAUAAAACQ3NWExMzU4My01Yzk5LTQwZTMtODFmYy01NDEwODRkZmM3ODQA"
+
+  val expected1 = List(
+    "CFe23a",
+    "web",
+    "2014-02-02 22:01:20.941",
+    "2014-02-02 22:01:21.071",
+    "struct",
+    "com.snowplowanalytics",
+    Uuid4Regexp, // Regexp match
+    "344214",
+    "js-0.13.1",
+    "ssc-0.1.0-stdout",
+    EnrichVersion,
+    "alex 123",
+    "10.0.2.x",
+    "1804954790",
+    "3c1757544e39bca4",
+    "26",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "file",
+    "file",
+    "80",
+    "///Users/alex/Development/dev-environment/demo/1-tracker/events.html/overridden-url/",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "impression",
+    "b",
+    "rtwork1",
+    "",
+    "0.0",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.9; rv:26.0) Gecko/20100101 Firefox/26.0",
+    "Firefox 26",
+    "Firefox",
+    "26.0",
+    "Browser",
+    "GECKO",
+    "en-US",
+    "0",
+    "1",
+    "0",
+    "0",
+    "1",
+    "0",
+    "0",
+    "0",
+    "0",
+    "1",
+    "24",
+    "1680",
+    "415",
+    "Mac OS X",
+    "Mac OS X",
+    "Apple Inc.",
+    "Europe/London",
+    "Computer",
+    "0",
+    "1920",
+    "1080",
+    "UTF-8",
+    "1680",
+    "415"
+  )
+
+  val expected2 = List(
+    "CFe23a",
+    "web",
+    "2014-02-02 22:01:20.941",
+    "2014-02-02 22:01:21.071",
+    "struct",
+    "com.snowplowanalytics",
+    Uuid4Regexp, // Regexp match
+    "344214",
+    "js-0.13.1",
+    "ssc-0.1.0-stdout",
+    EnrichVersion,
+    "alex 123",
+    "10.0.2.x",
+    "1804954790",
+    "3c1757544e39bca4",
+    "26",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "file",
+    "file",
+    "80",
+    "///Users/alex/Development/dev-environment/demo/1-tracker/events.html/overridden-url/",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "impression",
+    "b",
+    "artwork02",
+    "",
+    "0.0",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.9; rv:26.0) Gecko/20100101 Firefox/26.0",
+    "Firefox 26",
+    "Firefox",
+    "26.0",
+    "Browser",
+    "GECKO",
+    "en-US",
+    "0",
+    "1",
+    "0",
+    "0",
+    "1",
+    "0",
+    "0",
+    "0",
+    "0",
+    "1",
+    "24",
+    "1680",
+    "415",
+    "Mac OS X",
+    "Mac OS X",
+    "Apple Inc.",
+    "Europe/London",
+    "Computer",
+    "0",
+    "1920",
+    "1080",
+    "UTF-8",
+    "1680",
+    "415"
+  )
+}
+
+class ImpressionEventSpec extends Specification {
+
+  "Scala Kinesis Enrich" should {
+
+    "enrich a valid structured event" in {
+
+      val rawEvent = Base64.decodeBase64(ImpressionEventSpec.raw)
+
+      val enrichedEvents = TestSource.enrichEvent(rawEvent)
+      enrichedEvents.length must_== 2
+
+      val fields1 = enrichedEvents(0).get.split("\t")
+      fields1.size must beEqualTo(ImpressionEventSpec.expected1.size)
+      val fields2 = enrichedEvents(1).get.split("\t")
+      fields2.size must beEqualTo(ImpressionEventSpec.expected2.size)
+
+      Result.unit(
+        for (idx <- ImpressionEventSpec.expected1.indices) {
+          fields1(idx) must beFieldEqualTo(ImpressionEventSpec.expected1(idx), withIndex = idx)
+        }
+      )
+      Result.unit(
+        for (idx <- ImpressionEventSpec.expected2.indices) {
+          fields2(idx) must beFieldEqualTo(ImpressionEventSpec.expected2(idx), withIndex = idx)
+        }
+      )
+    }
+  }
+}

--- a/3-enrich/scala-kinesis-enrich/src/test/scala/com.snowplowanalytics.snowplow.enrich.kinesis/good/PagePingWithContextSpec.scala
+++ b/3-enrich/scala-kinesis-enrich/src/test/scala/com.snowplowanalytics.snowplow.enrich.kinesis/good/PagePingWithContextSpec.scala
@@ -1,4 +1,4 @@
-/* 
+/*
  * Copyright (c) 2013-2014 Snowplow Analytics Ltd. All rights reserved.
  *
  * This program is licensed to you under the Apache License Version 2.0, and
@@ -139,11 +139,11 @@ class PagePingWithContextSpec extends Specification {
     "enrich a valid page ping with context" in {
 
       val rawEvent = Base64.decodeBase64(PagePingWithContextSpec.raw)
-      
-      val enrichedEvent = TestSource.enrichEvent(rawEvent)
-      enrichedEvent must beSome
 
-      val fields = enrichedEvent.get.split("\t")
+      val enrichedEvents = TestSource.enrichEvent(rawEvent)
+      enrichedEvents.length must_== 1
+
+      val fields = enrichedEvents(0).get.split("\t")
       fields.size must beEqualTo(PagePingWithContextSpec.expected.size)
 
       Result.unit(

--- a/3-enrich/scala-kinesis-enrich/src/test/scala/com.snowplowanalytics.snowplow.enrich.kinesis/good/PageViewWithContextSpec.scala
+++ b/3-enrich/scala-kinesis-enrich/src/test/scala/com.snowplowanalytics.snowplow.enrich.kinesis/good/PageViewWithContextSpec.scala
@@ -1,4 +1,4 @@
-/* 
+/*
  * Copyright (c) 2013-2014 Snowplow Analytics Ltd. All rights reserved.
  *
  * This program is licensed to you under the Apache License Version 2.0, and
@@ -139,11 +139,11 @@ class PageViewWithContextSpec extends Specification {
     "enrich a valid page view with context" in {
 
       val rawEvent = Base64.decodeBase64(PageViewWithContextSpec.raw)
-      
-      val enrichedEvent = TestSource.enrichEvent(rawEvent)
-      enrichedEvent must beSome
 
-      val fields = enrichedEvent.get.split("\t")
+      val enrichedEvents = TestSource.enrichEvent(rawEvent)
+      enrichedEvents.length must_== 1
+
+      val fields = enrichedEvents(0).get.split("\t")
       fields.size must beEqualTo(PageViewWithContextSpec.expected.size)
 
       Result.unit(

--- a/3-enrich/scala-kinesis-enrich/src/test/scala/com.snowplowanalytics.snowplow.enrich.kinesis/good/StructEventSpec.scala
+++ b/3-enrich/scala-kinesis-enrich/src/test/scala/com.snowplowanalytics.snowplow.enrich.kinesis/good/StructEventSpec.scala
@@ -1,4 +1,4 @@
-/* 
+/*
  * Copyright (c) 2013-2014 Snowplow Analytics Ltd. All rights reserved.
  *
  * This program is licensed to you under the Apache License Version 2.0, and
@@ -139,11 +139,11 @@ class StructEventSpec extends Specification {
     "enrich a valid structured event" in {
 
       val rawEvent = Base64.decodeBase64(StructEventSpec.raw)
-      
-      val enrichedEvent = TestSource.enrichEvent(rawEvent)
-      enrichedEvent must beSome
 
-      val fields = enrichedEvent.get.split("\t")
+      val enrichedEvents = TestSource.enrichEvent(rawEvent)
+      enrichedEvents.length must_== 1
+
+      val fields = enrichedEvents(0).get.split("\t")
       fields.size must beEqualTo(StructEventSpec.expected.size)
 
       Result.unit(

--- a/3-enrich/scala-kinesis-enrich/src/test/scala/com.snowplowanalytics.snowplow.enrich.kinesis/good/StructEventWithContextSpec.scala
+++ b/3-enrich/scala-kinesis-enrich/src/test/scala/com.snowplowanalytics.snowplow.enrich.kinesis/good/StructEventWithContextSpec.scala
@@ -1,4 +1,4 @@
-/* 
+/*
  * Copyright (c) 2013-2014 Snowplow Analytics Ltd. All rights reserved.
  *
  * This program is licensed to you under the Apache License Version 2.0, and
@@ -139,11 +139,11 @@ class StructEventWithContextSpec extends Specification {
     "enrich a valid structured event with context" in {
 
       val rawEvent = Base64.decodeBase64(StructEventWithContextSpec.raw)
-      
-      val enrichedEvent = TestSource.enrichEvent(rawEvent)
-      enrichedEvent must beSome
 
-      val fields = enrichedEvent.get.split("\t")
+      val enrichedEvents = TestSource.enrichEvent(rawEvent)
+      enrichedEvents.length must_== 1
+
+      val fields = enrichedEvents(0).get.split("\t")
       fields.size must beEqualTo(StructEventWithContextSpec.expected.size)
 
       Result.unit(

--- a/3-enrich/scala-kinesis-enrich/src/test/scala/com.snowplowanalytics.snowplow.enrich.kinesis/good/TransactionItemSpec.scala
+++ b/3-enrich/scala-kinesis-enrich/src/test/scala/com.snowplowanalytics.snowplow.enrich.kinesis/good/TransactionItemSpec.scala
@@ -1,4 +1,4 @@
-/* 
+/*
  * Copyright (c) 2013-2014 Snowplow Analytics Ltd. All rights reserved.
  *
  * This program is licensed to you under the Apache License Version 2.0, and
@@ -139,11 +139,11 @@ class TransactionItemSpec extends Specification {
     "enrich a valid transaction item" in {
 
       val rawEvent = Base64.decodeBase64(TransactionItemSpec.raw)
-      
-      val enrichedEvent = TestSource.enrichEvent(rawEvent)
-      enrichedEvent must beSome
 
-      val fields = enrichedEvent.get.split("\t")
+      val enrichedEvents = TestSource.enrichEvent(rawEvent)
+      enrichedEvents.length must_== 1
+
+      val fields = enrichedEvents(0).get.split("\t")
       fields.size must beEqualTo(TransactionItemSpec.expected.size)
 
       Result.unit(

--- a/3-enrich/scala-kinesis-enrich/src/test/scala/com.snowplowanalytics.snowplow.enrich.kinesis/good/TransactionSpec.scala
+++ b/3-enrich/scala-kinesis-enrich/src/test/scala/com.snowplowanalytics.snowplow.enrich.kinesis/good/TransactionSpec.scala
@@ -1,4 +1,4 @@
-/* 
+/*
  * Copyright (c) 2013-2014 Snowplow Analytics Ltd. All rights reserved.
  *
  * This program is licensed to you under the Apache License Version 2.0, and
@@ -139,11 +139,11 @@ class TransactionSpec extends Specification {
     "enrich a valid transaction" in {
 
       val rawEvent = Base64.decodeBase64(TransactionSpec.raw)
-      
-      val enrichedEvent = TestSource.enrichEvent(rawEvent)
-      enrichedEvent must beSome
 
-      val fields = enrichedEvent.get.split("\t")
+      val enrichedEvents = TestSource.enrichEvent(rawEvent)
+      enrichedEvents.length must_== 1
+
+      val fields = enrichedEvents(0).get.split("\t")
       fields.size must beEqualTo(TransactionSpec.expected.size)
 
       Result.unit(


### PR DESCRIPTION
This adds two things.

- Impressions get put on their own stream.
- expect an array of CannonicalOutputs when you enrich an event, and put each of them on a stream

Initially, I was really ambitious and wanted to take advantage of the type system for this special case... But eventually I was worn down and use the se_category  (our designation of event type) to check if the event should be treated as a special impression and stuck onto its own kinesis stream.